### PR TITLE
Feature user compacter progress

### DIFF
--- a/src/main/java/org/joelson/turf/dailyinc/model/UserProgress.java
+++ b/src/main/java/org/joelson/turf/dailyinc/model/UserProgress.java
@@ -1,6 +1,9 @@
 package org.joelson.turf.dailyinc.model;
 
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
@@ -15,10 +18,15 @@ import java.util.Objects;
 @Entity
 @IdClass(UserProgressId.class)
 @Table(name = "user_progress", indexes = { @Index(name = "index_user_progress_user_id", columnList = "user_id"),
-        @Index(name = "index_user_progress_type", columnList = "type"),
         @Index(name = "index_user_progress_date", columnList = "date"),
-        @Index(name = "index_user_progress_day_completed", columnList = "day_completed"),
-        @Index(name = "index_user_progress_time_completed", columnList = "time_completed") })
+        @Index(name = "index_user_progress_inc_comp", columnList = "inc_comp"),
+        @Index(name = "index_user_progress_inc_time", columnList = "inc_time"),
+        @Index(name = "index_user_progress_add_comp", columnList = "add_comp"),
+        @Index(name = "index_user_progress_add_time", columnList = "add_time"),
+        @Index(name = "index_user_progress_fib_comp", columnList = "fib_comp"),
+        @Index(name = "index_user_progress_fib_time", columnList = "fib_time"),
+        @Index(name = "index_user_progress_pow_comp", columnList = "pow_comp"),
+        @Index(name = "index_user_progress_pow_time", columnList = "pow_time") })
 public class UserProgress {
 
     @Id
@@ -28,68 +36,74 @@ public class UserProgress {
 
     @Id
     @Column(updatable = false, nullable = false)
-    private UserProgressType type;
-
-    @Id
-    @Column(updatable = false, nullable = false)
     private Instant date;
 
-    @Column(name = "previous_day_completed", updatable = false, nullable = false)
-    private Integer previousDayCompleted;
+    @Embedded
+    @AttributeOverrides({ @AttributeOverride(name = "previous",
+            column = @Column(name = "inc_prev", updatable = false, nullable = false)),
+            @AttributeOverride(name = "completed", column = @Column(name = "inc_comp", nullable = false)),
+            @AttributeOverride(name = "time", column = @Column(name = "inc_time", nullable = false)) })
+    private UserProgressTypeProgress increase;
 
-    @Column(name = "day_completed", nullable = false)
-    private Integer dayCompleted;
+    @Embedded
+    @AttributeOverrides({ @AttributeOverride(name = "previous",
+            column = @Column(name = "add_prev", updatable = false, nullable = false)),
+            @AttributeOverride(name = "completed", column = @Column(name = "add_comp", nullable = false)),
+            @AttributeOverride(name = "time", column = @Column(name = "add_time", nullable = false)) })
+    private UserProgressTypeProgress add;
 
-    @Column(name = "time_completed", nullable = false)
-    private Instant timeCompleted;
+    @Embedded
+    @AttributeOverrides({ @AttributeOverride(name = "previous",
+            column = @Column(name = "fib_prev", updatable = false, nullable = false)),
+            @AttributeOverride(name = "completed", column = @Column(name = "fib_comp", nullable = false)),
+            @AttributeOverride(name = "time", column = @Column(name = "fib_time", nullable = false)) })
+    private UserProgressTypeProgress fibonnaci;
+
+    @Embedded
+    @AttributeOverrides({ @AttributeOverride(name = "previous",
+            column = @Column(name = "pow_prev", updatable = false, nullable = false)),
+            @AttributeOverride(name = "completed", column = @Column(name = "pow_comp", nullable = false)),
+            @AttributeOverride(name = "time", column = @Column(name = "pow_time", nullable = false)) })
+    private UserProgressTypeProgress powerOfTwo;
+
 
     protected UserProgress() {
     }
 
     public UserProgress(
-            User user, UserProgressType type, Instant date, Integer previousDayCompleted, Integer dayCompleted,
-            Instant timeCompleted) {
+            User user, Instant date, UserProgressTypeProgress increase, UserProgressTypeProgress add,
+            UserProgressTypeProgress fibonnaci, UserProgressTypeProgress powerOfTwo) {
         this.user = Objects.requireNonNull(user);
-        this.type = Objects.requireNonNull(type);
         this.date = ModelConstraintsUtil.isTruncatedToDays(date);
-        this.previousDayCompleted = ModelConstraintsUtil.isEqualOrAboveZero(previousDayCompleted);
-        setDayCompleted(dayCompleted);
-        setTimeCompleted(timeCompleted);
+        this.increase = Objects.requireNonNull(increase);
+        this.add = Objects.requireNonNull(add);
+        this.fibonnaci = Objects.requireNonNull(fibonnaci);
+        this.powerOfTwo = Objects.requireNonNull(powerOfTwo);
     }
 
     public User getUser() {
         return user;
     }
 
-    public UserProgressType getType() {
-        return type;
-    }
-
     public Instant getDate() {
         return date;
     }
 
-    public Integer getPreviousDayCompleted() {
-        return previousDayCompleted;
+
+    public UserProgressTypeProgress getIncrease() {
+        return increase;
     }
 
-    public Integer getDayCompleted() {
-        return dayCompleted;
+    public UserProgressTypeProgress getAdd() {
+        return add;
     }
 
-    public void setDayCompleted(Integer dayCompleted) {
-        this.dayCompleted = ModelConstraintsUtil.isEqualOrBelow(
-                ModelConstraintsUtil.isEqualOrAbove(ModelConstraintsUtil.isAboveZero(dayCompleted), this.dayCompleted),
-                this.previousDayCompleted + 1);
+    public UserProgressTypeProgress getFibonnaci() {
+        return fibonnaci;
     }
 
-    public Instant getTimeCompleted() {
-        return timeCompleted;
-    }
-
-    public void setTimeCompleted(Instant timeCompleted) {
-        this.timeCompleted =
-                ModelConstraintsUtil.isEqualOrAbove(ModelConstraintsUtil.isTruncatedToSeconds(timeCompleted), this.timeCompleted);
+    public UserProgressTypeProgress getPowerOfTwo() {
+        return powerOfTwo;
     }
 
     @Override
@@ -98,23 +112,22 @@ public class UserProgress {
             return true;
         }
         if (o instanceof UserProgress that) {
-            return Objects.equals(user, that.user) && type == that.type && Objects.equals(date, that.date)
-                    && Objects.equals(previousDayCompleted, that.previousDayCompleted)
-                    && Objects.equals(dayCompleted, that.dayCompleted)
-                    && Objects.equals(timeCompleted, that.timeCompleted);
+            return Objects.equals(user, that.user) && Objects.equals(date, that.date)
+                    && Objects.equals(increase, that.increase) && Objects.equals(add, that.add)
+                    && Objects.equals(fibonnaci, that.fibonnaci) && Objects.equals(powerOfTwo, that.powerOfTwo);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(user, type, date);
+        return Objects.hash(user, date);
     }
 
     @Override
     public String toString() {
-        return String.format(
-                "UserProgress[user=%s, type=%s, date=%s, previousDayCompleted=%d, dayCompleted=%s, timeCompleted=%s",
-                user, type, date, previousDayCompleted, dayCompleted, timeCompleted);
+        return String.format("UserProgress[user=%s, type=%s, %s, %s, %s, %s]", user, date,
+                increase.toInnerString("increase"), add.toInnerString("add"), fibonnaci.toInnerString("fibonacci"),
+                powerOfTwo.toInnerString("powerOfTwo"));
     }
 }

--- a/src/main/java/org/joelson/turf/dailyinc/model/UserProgress.java
+++ b/src/main/java/org/joelson/turf/dailyinc/model/UserProgress.java
@@ -57,7 +57,7 @@ public class UserProgress {
             column = @Column(name = "fib_prev", updatable = false, nullable = false)),
             @AttributeOverride(name = "completed", column = @Column(name = "fib_comp", nullable = false)),
             @AttributeOverride(name = "time", column = @Column(name = "fib_time", nullable = false)) })
-    private UserProgressTypeProgress fibonnaci;
+    private UserProgressTypeProgress fibonacci;
 
     @Embedded
     @AttributeOverrides({ @AttributeOverride(name = "previous",
@@ -72,12 +72,12 @@ public class UserProgress {
 
     public UserProgress(
             User user, Instant date, UserProgressTypeProgress increase, UserProgressTypeProgress add,
-            UserProgressTypeProgress fibonnaci, UserProgressTypeProgress powerOfTwo) {
+            UserProgressTypeProgress fibonacci, UserProgressTypeProgress powerOfTwo) {
         this.user = Objects.requireNonNull(user);
         this.date = ModelConstraintsUtil.isTruncatedToDays(date);
         this.increase = Objects.requireNonNull(increase);
         this.add = Objects.requireNonNull(add);
-        this.fibonnaci = Objects.requireNonNull(fibonnaci);
+        this.fibonacci = Objects.requireNonNull(fibonacci);
         this.powerOfTwo = Objects.requireNonNull(powerOfTwo);
     }
 
@@ -98,8 +98,8 @@ public class UserProgress {
         return add;
     }
 
-    public UserProgressTypeProgress getFibonnaci() {
-        return fibonnaci;
+    public UserProgressTypeProgress getFibonacci() {
+        return fibonacci;
     }
 
     public UserProgressTypeProgress getPowerOfTwo() {
@@ -114,7 +114,7 @@ public class UserProgress {
         if (o instanceof UserProgress that) {
             return Objects.equals(user, that.user) && Objects.equals(date, that.date)
                     && Objects.equals(increase, that.increase) && Objects.equals(add, that.add)
-                    && Objects.equals(fibonnaci, that.fibonnaci) && Objects.equals(powerOfTwo, that.powerOfTwo);
+                    && Objects.equals(fibonacci, that.fibonacci) && Objects.equals(powerOfTwo, that.powerOfTwo);
         }
         return false;
     }
@@ -127,7 +127,7 @@ public class UserProgress {
     @Override
     public String toString() {
         return String.format("UserProgress[user=%s, type=%s, %s, %s, %s, %s]", user, date,
-                increase.toInnerString("increase"), add.toInnerString("add"), fibonnaci.toInnerString("fibonacci"),
+                increase.toInnerString("increase"), add.toInnerString("add"), fibonacci.toInnerString("fibonacci"),
                 powerOfTwo.toInnerString("powerOfTwo"));
     }
 }

--- a/src/main/java/org/joelson/turf/dailyinc/model/UserProgressId.java
+++ b/src/main/java/org/joelson/turf/dailyinc/model/UserProgressId.java
@@ -6,15 +6,13 @@ import java.util.Objects;
 public class UserProgressId {
 
     private Long user;
-    private UserProgressType type;
     private Instant date;
 
     protected UserProgressId() {
     }
 
-    public UserProgressId(Long user, UserProgressType type, Instant date) {
+    public UserProgressId(Long user, Instant date) {
         setUser(user);
-        setType(type);
         setDate(date);
     }
 
@@ -24,14 +22,6 @@ public class UserProgressId {
 
     public void setUser(Long user) {
         this.user = ModelConstraintsUtil.isAboveZero(user);
-    }
-
-    public UserProgressType getType() {
-        return type;
-    }
-
-    public void setType(UserProgressType type) {
-        this.type = Objects.requireNonNull(type);
     }
 
     public Instant getDate() {
@@ -48,18 +38,18 @@ public class UserProgressId {
             return true;
         }
         if (o instanceof UserProgressId that) {
-            return Objects.equals(user, that.user) && type == that.type && Objects.equals(date, that.date);
+            return Objects.equals(user, that.user) && Objects.equals(date, that.date);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(user, type, date);
+        return Objects.hash(user, date);
     }
 
     @Override
     public String toString() {
-        return String.format("UserProgressId[user=%d, type=%s, date=%s", user, type, date);
+        return String.format("UserProgressId[user=%d, date=%s]", user, date);
     }
 }

--- a/src/main/java/org/joelson/turf/dailyinc/model/UserProgressRepository.java
+++ b/src/main/java/org/joelson/turf/dailyinc/model/UserProgressRepository.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 public interface UserProgressRepository extends JpaRepository<UserProgress, UserProgressId> {
 
-    @Query("select up from UserProgress up order by up.user.id, up.type, up.date")
+    @Query("select up from UserProgress up order by up.user.id, up.date")
     <T> List<T> findAllSorted(Class<T> type);
 
-    @Query("select up from UserProgress up where up.user.id = :userId order by up.type, up.date")
+    @Query("select up from UserProgress up where up.user.id = :userId order by up.date")
     <T> List<T> findAllSortedByUser(Long userId, Class<T> type);
 }

--- a/src/main/java/org/joelson/turf/dailyinc/model/UserProgressTypeProgress.java
+++ b/src/main/java/org/joelson/turf/dailyinc/model/UserProgressTypeProgress.java
@@ -1,0 +1,73 @@
+package org.joelson.turf.dailyinc.model;
+
+import jakarta.persistence.Embeddable;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Embeddable
+public class UserProgressTypeProgress {
+
+    private Integer previous;
+    private Integer completed;
+    private Instant time;
+
+    protected UserProgressTypeProgress() {
+    }
+
+    public UserProgressTypeProgress(
+            Integer previous, Integer completed, Instant time) {
+        this.previous = ModelConstraintsUtil.isEqualOrAboveZero(previous);
+        setCompleted(completed);
+        setTime(time);
+    }
+
+    public Integer getPrevious() {
+        return previous;
+    }
+
+    public Integer getCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(Integer completed) {
+        this.completed = ModelConstraintsUtil.isEqualOrBelow(
+                ModelConstraintsUtil.isEqualOrAbove(ModelConstraintsUtil.isAboveZero(completed), this.completed),
+                this.previous + 1);
+    }
+
+    public Instant getTime() {
+        return time;
+    }
+
+    public void setTime(Instant time) {
+        this.time = ModelConstraintsUtil.isEqualOrAbove(ModelConstraintsUtil.isTruncatedToSeconds(time), this.time);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof UserProgressTypeProgress that) {
+            return Objects.equals(previous, that.previous) && Objects.equals(completed, that.completed)
+                    && Objects.equals(time, that.time);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(previous, completed, time);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("UserProgressTypeProgress[previous=%d, completed=%d, time=%s]", previous, completed, time);
+    }
+
+    public String toInnerString(String type) {
+        return String.format("%s.previous=%d, %s.completed=%d, %s.time=%s", type, previous, type, completed, type,
+                time);
+    }
+}

--- a/src/main/java/org/joelson/turf/dailyinc/projection/UserIdAndNameProgress.java
+++ b/src/main/java/org/joelson/turf/dailyinc/projection/UserIdAndNameProgress.java
@@ -1,6 +1,7 @@
 package org.joelson.turf.dailyinc.projection;
 
 import org.joelson.turf.dailyinc.model.UserProgressType;
+import org.joelson.turf.dailyinc.model.UserProgressTypeProgress;
 
 import java.time.Instant;
 
@@ -8,13 +9,13 @@ public interface UserIdAndNameProgress {
 
     UserIdAndName getUser();
 
-    UserProgressType getType();
-
     Instant getDate();
 
-    Integer getPreviousDayCompleted();
+    UserProgressTypeProgress getIncrease();
 
-    Integer getDayCompleted();
+    UserProgressTypeProgress getAdd();
 
-    Instant getTimeCompleted();
+    UserProgressTypeProgress getFibonacci();
+
+    UserProgressTypeProgress getPowerOfTwo();
 }

--- a/src/main/java/org/joelson/turf/dailyinc/service/UserProgressService.java
+++ b/src/main/java/org/joelson/turf/dailyinc/service/UserProgressService.java
@@ -56,7 +56,7 @@ public class UserProgressService {
 
             int addCompleted = increaseUserProgress(userProgress.getAdd(), visits, time,
                     UserProgressType.DAILY_ADD::getNeededVisits);
-            if (increaseCompleted > 0) {
+            if (addCompleted > 0) {
                 updated = true;
                 maxDayCompleted = Math.max(maxDayCompleted, addCompleted);
             } else {
@@ -65,7 +65,7 @@ public class UserProgressService {
 
             int fiboniacciCompleted = increaseUserProgress(userProgress.getFibonnaci(), visits, time,
                     UserProgressType.DAILY_FIBONACCI::getNeededVisits);
-            if (increaseCompleted > 0) {
+            if (fiboniacciCompleted > 0) {
                 updated = true;
                 maxDayCompleted = Math.max(maxDayCompleted, fiboniacciCompleted);
             } else {
@@ -74,7 +74,7 @@ public class UserProgressService {
 
             int powerCompleted = increaseUserProgress(userProgress.getPowerOfTwo(), visits, time,
                     UserProgressType.DAILY_POWER_OF_TWO::getNeededVisits);
-            if (increaseCompleted > 0) {
+            if (powerCompleted > 0) {
                 updated = true;
                 maxDayCompleted = Math.max(maxDayCompleted, powerCompleted);
             } else {

--- a/src/main/java/org/joelson/turf/dailyinc/service/UserProgressService.java
+++ b/src/main/java/org/joelson/turf/dailyinc/service/UserProgressService.java
@@ -42,16 +42,16 @@ public class UserProgressService {
                 return 2;
             }
         } else {
-            int maxDayCompleted = -1;
+            int maxDayCompleted;
             boolean updated = false;
 
             int increaseCompleted = increaseUserProgress(userProgress.getIncrease(), visits, time,
                     UserProgressType.DAILY_INCREASE::getNeededVisits);
             if (increaseCompleted > 0) {
                 updated = true;
-                maxDayCompleted = Math.max(maxDayCompleted, increaseCompleted);
+                maxDayCompleted = increaseCompleted;
             } else {
-                maxDayCompleted = Math.max(maxDayCompleted, -increaseCompleted);
+                maxDayCompleted = -increaseCompleted;
             }
 
             int addCompleted = increaseUserProgress(userProgress.getAdd(), visits, time,

--- a/src/main/java/org/joelson/turf/dailyinc/service/UserProgressService.java
+++ b/src/main/java/org/joelson/turf/dailyinc/service/UserProgressService.java
@@ -5,11 +5,13 @@ import org.joelson.turf.dailyinc.model.UserProgress;
 import org.joelson.turf.dailyinc.model.UserProgressId;
 import org.joelson.turf.dailyinc.model.UserProgressRepository;
 import org.joelson.turf.dailyinc.model.UserProgressType;
+import org.joelson.turf.dailyinc.model.UserProgressTypeProgress;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.function.Function;
 
 @Service
 public class UserProgressService {
@@ -17,49 +19,87 @@ public class UserProgressService {
     @Autowired
     UserProgressRepository userProgressRepository;
 
-    private UserProgress getUserProgress(User user, UserProgressType type, Instant date) {
-        return userProgressRepository.findById(new UserProgressId(user.getId(), type, date)).orElse(null);
+    private UserProgress getUserProgress(User user, Instant date) {
+        return userProgressRepository.findById(new UserProgressId(user.getId(), date)).orElse(null);
     }
 
     public int increaseUserProgress(User user, Instant date, int visits, Instant time) {
-        int maxDayCompleted = -1;
-        for (UserProgressType type : UserProgressType.values()) {
-            int dayCompleted = increaseUserProgress(user, type, date, visits, time);
-            if (dayCompleted > maxDayCompleted) {
-                maxDayCompleted = dayCompleted;
-            }
-        }
-        return maxDayCompleted;
-    }
-
-    private int increaseUserProgress(User user, UserProgressType type, Instant date, int visits, Instant time) {
-        UserProgress userProgress = getUserProgress(user, type, date);
+        UserProgress userProgress = getUserProgress(user, date);
         if (userProgress == null) {
             Instant previousDate = date.minus(1, ChronoUnit.DAYS);
-            UserProgress previousUserProgress = getUserProgress(user, type, previousDate);
+            UserProgress previousUserProgress = getUserProgress(user, previousDate);
             if (previousUserProgress == null) {
-                userProgressRepository.save(new UserProgress(user, type, date, 0, 1, time));
+                userProgressRepository.save(new UserProgress(user, date, new UserProgressTypeProgress(0, 1, time),
+                        new UserProgressTypeProgress(0, 1, time), new UserProgressTypeProgress(0, 1, time),
+                        new UserProgressTypeProgress(0, 1, time)));
                 return 1;
-            } else if (type == UserProgressType.DAILY_FIBONACCI) {
-                userProgressRepository.save(
-                        new UserProgress(user, type, date, previousUserProgress.getDayCompleted(), 2, time));
-                return 2;
             } else {
-                userProgressRepository.save(
-                        new UserProgress(user, type, date, previousUserProgress.getDayCompleted(), 1, time));
-                return 1;
+                userProgressRepository.save(new UserProgress(user, date,
+                        new UserProgressTypeProgress(previousUserProgress.getIncrease().getCompleted(), 1, time),
+                        new UserProgressTypeProgress(previousUserProgress.getAdd().getCompleted(), 1, time),
+                        new UserProgressTypeProgress(previousUserProgress.getFibonnaci().getCompleted(), 2, time),
+                        new UserProgressTypeProgress(previousUserProgress.getPowerOfTwo().getCompleted(), 1, time)));
+                return 2;
             }
         } else {
-            Integer dayCompleted = userProgress.getDayCompleted();
-            if (dayCompleted <= userProgress.getPreviousDayCompleted()) {
-                int visitsNeeded = type.getNeededVisits(dayCompleted + 1);
-                if (visits >= visitsNeeded) {
-                    userProgress.setDayCompleted(dayCompleted + 1);
-                    userProgress.setTimeCompleted(time);
-                    userProgressRepository.save(userProgress);
-                }
+            int maxDayCompleted = -1;
+            boolean updated = false;
+
+            int increaseCompleted = increaseUserProgress(userProgress.getIncrease(), visits, time,
+                    UserProgressType.DAILY_INCREASE::getNeededVisits);
+            if (increaseCompleted > 0) {
+                updated = true;
+                maxDayCompleted = Math.max(maxDayCompleted, increaseCompleted);
+            } else {
+                maxDayCompleted = Math.max(maxDayCompleted, -increaseCompleted);
             }
-            return userProgress.getDayCompleted();
+
+            int addCompleted = increaseUserProgress(userProgress.getAdd(), visits, time,
+                    UserProgressType.DAILY_ADD::getNeededVisits);
+            if (increaseCompleted > 0) {
+                updated = true;
+                maxDayCompleted = Math.max(maxDayCompleted, addCompleted);
+            } else {
+                maxDayCompleted = Math.max(maxDayCompleted, -addCompleted);
+            }
+
+            int fiboniacciCompleted = increaseUserProgress(userProgress.getFibonnaci(), visits, time,
+                    UserProgressType.DAILY_FIBONACCI::getNeededVisits);
+            if (increaseCompleted > 0) {
+                updated = true;
+                maxDayCompleted = Math.max(maxDayCompleted, fiboniacciCompleted);
+            } else {
+                maxDayCompleted = Math.max(maxDayCompleted, -fiboniacciCompleted);
+            }
+
+            int powerCompleted = increaseUserProgress(userProgress.getPowerOfTwo(), visits, time,
+                    UserProgressType.DAILY_POWER_OF_TWO::getNeededVisits);
+            if (increaseCompleted > 0) {
+                updated = true;
+                maxDayCompleted = Math.max(maxDayCompleted, powerCompleted);
+            } else {
+                maxDayCompleted = Math.max(maxDayCompleted, -powerCompleted);
+            }
+
+            if (updated) {
+                userProgressRepository.save(userProgress);
+            }
+            return maxDayCompleted;
         }
+    }
+
+    private int increaseUserProgress(
+            UserProgressTypeProgress userProgressTypeProgress, int visits, Instant time,
+            Function<Integer, Integer> neededVisits) {
+        Integer completed = userProgressTypeProgress.getCompleted();
+        if (completed <= userProgressTypeProgress.getPrevious()) {
+            int visitsNeeded = neededVisits.apply(completed + 1);
+            if (visits >= visitsNeeded) {
+                userProgressTypeProgress.setCompleted(completed + 1);
+                userProgressTypeProgress.setTime(time);
+                return completed + 1;
+            }
+        }
+        return -userProgressTypeProgress.getCompleted();
     }
 }

--- a/src/main/java/org/joelson/turf/dailyinc/service/UserProgressService.java
+++ b/src/main/java/org/joelson/turf/dailyinc/service/UserProgressService.java
@@ -37,7 +37,7 @@ public class UserProgressService {
                 userProgressRepository.save(new UserProgress(user, date,
                         new UserProgressTypeProgress(previousUserProgress.getIncrease().getCompleted(), 1, time),
                         new UserProgressTypeProgress(previousUserProgress.getAdd().getCompleted(), 1, time),
-                        new UserProgressTypeProgress(previousUserProgress.getFibonnaci().getCompleted(), 2, time),
+                        new UserProgressTypeProgress(previousUserProgress.getFibonacci().getCompleted(), 2, time),
                         new UserProgressTypeProgress(previousUserProgress.getPowerOfTwo().getCompleted(), 1, time)));
                 return 2;
             }
@@ -63,13 +63,13 @@ public class UserProgressService {
                 maxDayCompleted = Math.max(maxDayCompleted, -addCompleted);
             }
 
-            int fiboniacciCompleted = increaseUserProgress(userProgress.getFibonnaci(), visits, time,
+            int fibonacciCompleted = increaseUserProgress(userProgress.getFibonacci(), visits, time,
                     UserProgressType.DAILY_FIBONACCI::getNeededVisits);
-            if (fiboniacciCompleted > 0) {
+            if (fibonacciCompleted > 0) {
                 updated = true;
-                maxDayCompleted = Math.max(maxDayCompleted, fiboniacciCompleted);
+                maxDayCompleted = Math.max(maxDayCompleted, fibonacciCompleted);
             } else {
-                maxDayCompleted = Math.max(maxDayCompleted, -fiboniacciCompleted);
+                maxDayCompleted = Math.max(maxDayCompleted, -fibonacciCompleted);
             }
 
             int powerCompleted = increaseUserProgress(userProgress.getPowerOfTwo(), visits, time,

--- a/src/test/java/org/joelson/turf/dailyinc/api/UserProgressAPIServiceTest.java
+++ b/src/test/java/org/joelson/turf/dailyinc/api/UserProgressAPIServiceTest.java
@@ -4,6 +4,7 @@ import org.joelson.turf.dailyinc.model.User;
 import org.joelson.turf.dailyinc.model.UserProgress;
 import org.joelson.turf.dailyinc.model.UserProgressRepository;
 import org.joelson.turf.dailyinc.model.UserProgressType;
+import org.joelson.turf.dailyinc.model.UserProgressTypeProgress;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -45,25 +46,26 @@ public class UserProgressAPIServiceTest {
     private static final Instant NEXT_DATE = DATE.plus(1, ChronoUnit.DAYS);
 
     private static final User USER_ONE = new User(1001L, "UserOne", NEXT_TIME);
-    private static final UserProgress USER_ONE_INC_PROGRESS = new UserProgress(USER_ONE,
-            UserProgressType.DAILY_INCREASE, DATE, 0, 1, TIME);
-    private static final UserProgress USER_ONE_NEXT_PROGRESS = new UserProgress(USER_ONE,
-            UserProgressType.DAILY_INCREASE, NEXT_DATE, 1, 2, NEXT_TIME);
-    private static final UserProgress USER_ONE_ADD_PROGRESS = new UserProgress(USER_ONE, UserProgressType.DAILY_ADD,
-            DATE, 0, 1, TIME);
+    private static final UserProgress USER_ONE_PROGRESS = new UserProgress(USER_ONE, DATE,
+            new UserProgressTypeProgress(0, 1, TIME), new UserProgressTypeProgress(0, 1, TIME),
+            new UserProgressTypeProgress(0, 1, TIME), new UserProgressTypeProgress(0, 1, TIME));
+    private static final UserProgress USER_ONE_NEXT_PROGRESS = new UserProgress(USER_ONE, NEXT_DATE,
+            new UserProgressTypeProgress(1, 2, TIME), new UserProgressTypeProgress(1, 2, TIME),
+            new UserProgressTypeProgress(1, 2, TIME), new UserProgressTypeProgress(1, 2, TIME));
 
     private static final User USER_TWO = new User(1002L, "UserTwo", NEXT_TIME);
-    private static final UserProgress USER_TWO_INC_PROGRESS = new UserProgress(USER_TWO,
-            UserProgressType.DAILY_INCREASE, DATE, 10, 10, TIME);
-    private static final UserProgress USER_TWO_NEXT_PROGRESS = new UserProgress(USER_TWO,
-            UserProgressType.DAILY_INCREASE, NEXT_DATE, 11, 12, TIME);
+    private static final UserProgress USER_TWO_PROGRESS = new UserProgress(USER_TWO, DATE,
+            new UserProgressTypeProgress(10, 10, TIME), new UserProgressTypeProgress(4, 4, TIME),
+            new UserProgressTypeProgress(6, 6, TIME), new UserProgressTypeProgress(4, 4, TIME));
+    private static final UserProgress USER_TWO_NEXT_PROGRESS = new UserProgress(USER_TWO, NEXT_DATE,
+            new UserProgressTypeProgress(10, 11, NEXT_TIME), new UserProgressTypeProgress(4, 4, NEXT_TIME),
+            new UserProgressTypeProgress(6, 7, NEXT_TIME), new UserProgressTypeProgress(4, 4, NEXT_TIME));
 
-    private static final List<UserProgress> SORTED_USER_PROGRESS = List.of(USER_ONE_INC_PROGRESS,
-            USER_ONE_NEXT_PROGRESS, USER_ONE_ADD_PROGRESS, USER_TWO_INC_PROGRESS, USER_TWO_NEXT_PROGRESS);
-
-    private static final List<UserProgress> USER_ONE_SORTED_USER_PROGRESS = List.of(USER_ONE_INC_PROGRESS,
-            USER_ONE_NEXT_PROGRESS, USER_ONE_ADD_PROGRESS);
-    private static final List<UserProgress> USER_TWO_SORTED_USER_PROGRESS = List.of(USER_TWO_INC_PROGRESS,
+    private static final List<UserProgress> SORTED_USER_PROGRESS = List.of(USER_ONE_PROGRESS, USER_ONE_NEXT_PROGRESS,
+            USER_TWO_PROGRESS, USER_TWO_NEXT_PROGRESS);
+    private static final List<UserProgress> USER_ONE_SORTED_USER_PROGRESS = List.of(USER_ONE_PROGRESS,
+            USER_ONE_NEXT_PROGRESS);
+    private static final List<UserProgress> USER_TWO_SORTED_USER_PROGRESS = List.of(USER_TWO_PROGRESS,
             USER_TWO_NEXT_PROGRESS);
 
     @Test

--- a/src/test/java/org/joelson/turf/dailyinc/model/UserProgressIdTest.java
+++ b/src/test/java/org/joelson/turf/dailyinc/model/UserProgressIdTest.java
@@ -12,17 +12,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class UserProgressIdTest {
 
     private static final Long USER = 2L;
-    private static final UserProgressType TYPE = UserProgressType.DAILY_INCREASE;
     private static final Instant DATE = Instant.now().truncatedTo(ChronoUnit.DAYS);
 
     @Test
     public void testUser() {
-        assertThrows(NullPointerException.class, () -> new UserProgressId(null, TYPE, DATE));
-        assertThrows(IllegalArgumentException.class, () -> new UserProgressId(0L, TYPE, DATE));
+        assertThrows(NullPointerException.class, () -> new UserProgressId(null, DATE));
+        assertThrows(IllegalArgumentException.class, () -> new UserProgressId(0L, DATE));
 
         Long user = USER + 3;
         assertNotEquals(USER, user);
-        UserProgressId userProgressId = new UserProgressId(user, TYPE, DATE);
+        UserProgressId userProgressId = new UserProgressId(user, DATE);
         assertEquals(user, userProgressId.getUser());
 
         Long newUser = user + 2;
@@ -36,31 +35,13 @@ public class UserProgressIdTest {
     }
 
     @Test
-    public void testType() {
-        assertThrows(NullPointerException.class, () -> new UserProgressId(USER, null, DATE));
-
-        UserProgressType type = UserProgressType.DAILY_ADD;
-        assertNotEquals(TYPE, type);
-        UserProgressId userProgressId = new UserProgressId(USER, type, DATE);
-        assertEquals(type, userProgressId.getType());
-
-        UserProgressType newType = UserProgressType.DAILY_FIBONACCI;
-        assertNotEquals(TYPE, newType);
-        assertNotEquals(type, newType);
-        userProgressId.setType(newType);
-        assertEquals(newType, userProgressId.getType());
-
-        assertThrows(NullPointerException.class, () -> userProgressId.setType(null));
-    }
-
-    @Test
     public void testDate() {
-        assertThrows(NullPointerException.class, () -> new UserProgressId(USER, TYPE, null));
-        assertThrows(IllegalArgumentException.class, () -> new UserProgressId(USER, TYPE, DATE.plusSeconds(3)));
+        assertThrows(NullPointerException.class, () -> new UserProgressId(USER, null));
+        assertThrows(IllegalArgumentException.class, () -> new UserProgressId(USER, DATE.plusSeconds(3)));
 
         Instant date = DATE.plus(5, ChronoUnit.DAYS);
         assertNotEquals(DATE, date);
-        UserProgressId userProgressId = new UserProgressId(USER, TYPE, date);
+        UserProgressId userProgressId = new UserProgressId(USER, date);
         assertEquals(date, userProgressId.getDate());
 
         Instant newDate = date.plus(2, ChronoUnit.DAYS);
@@ -75,40 +56,32 @@ public class UserProgressIdTest {
 
     @Test
     public void testEquals() {
-        UserProgressId userProgressId = new UserProgressId(USER, TYPE, DATE);
+        UserProgressId userProgressId = new UserProgressId(USER, DATE);
         assertEquals(userProgressId, userProgressId);
         assertNotEquals(userProgressId, null);
         assertNotEquals(userProgressId, new UserProgressId());
 
         Long user = USER + 7;
         assertNotEquals(USER, user);
-        assertNotEquals(userProgressId, new UserProgressId(user, TYPE, DATE));
-
-        UserProgressType type = UserProgressType.DAILY_ADD;
-        assertNotEquals(TYPE, type);
-        assertNotEquals(userProgressId, new UserProgressId(USER, type, DATE));
+        assertNotEquals(userProgressId, new UserProgressId(user, DATE));
 
         Instant date = DATE.plus(4, ChronoUnit.DAYS);
         assertNotEquals(DATE, date);
-        assertNotEquals(userProgressId, new UserProgressId(USER, TYPE, date));
+        assertNotEquals(userProgressId, new UserProgressId(USER, date));
     }
 
     @Test
     public void testHashCode() {
-        UserProgressId userProgressId = new UserProgressId(USER, TYPE, DATE);
+        UserProgressId userProgressId = new UserProgressId(USER, DATE);
         assertEquals(userProgressId.hashCode(), userProgressId.hashCode());
         assertNotEquals(userProgressId.hashCode(), new UserProgressId().hashCode());
 
         Long user = USER + 7;
         assertNotEquals(USER, user);
-        assertNotEquals(userProgressId.hashCode(), new UserProgressId(user, TYPE, DATE).hashCode());
-
-        UserProgressType type = UserProgressType.DAILY_ADD;
-        assertNotEquals(TYPE, type);
-        assertNotEquals(userProgressId.hashCode(), new UserProgressId(USER, type, DATE).hashCode());
+        assertNotEquals(userProgressId.hashCode(), new UserProgressId(user, DATE).hashCode());
 
         Instant date = DATE.plus(4, ChronoUnit.DAYS);
         assertNotEquals(DATE, date);
-        assertNotEquals(userProgressId.hashCode(), new UserProgressId(USER, TYPE, date).hashCode());
+        assertNotEquals(userProgressId.hashCode(), new UserProgressId(USER, date).hashCode());
     }
 }

--- a/src/test/java/org/joelson/turf/dailyinc/model/UserProgressRepositoryIntegrationTest.java
+++ b/src/test/java/org/joelson/turf/dailyinc/model/UserProgressRepositoryIntegrationTest.java
@@ -24,25 +24,26 @@ public class UserProgressRepositoryIntegrationTest {
     private static final Instant NEXT_DATE = DATE.plus(1, ChronoUnit.DAYS);
 
     private static final User USER_ONE = new User(1001L, "UserOne", NEXT_TIME);
-    private static final UserProgress USER_ONE_INC_PROGRESS = new UserProgress(USER_ONE,
-            UserProgressType.DAILY_INCREASE, DATE, 0, 1, TIME);
-    private static final UserProgress USER_ONE_NEXT_PROGRESS = new UserProgress(USER_ONE,
-            UserProgressType.DAILY_INCREASE, NEXT_DATE, 1, 2, NEXT_TIME);
-    private static final UserProgress USER_ONE_ADD_PROGRESS = new UserProgress(USER_ONE, UserProgressType.DAILY_ADD,
-            DATE, 0, 1, TIME);
+    private static final UserProgress USER_ONE_PROGRESS = new UserProgress(USER_ONE, DATE,
+            new UserProgressTypeProgress(0, 1, TIME), new UserProgressTypeProgress(0, 1, TIME),
+            new UserProgressTypeProgress(0, 1, TIME), new UserProgressTypeProgress(0, 1, TIME));
+    private static final UserProgress USER_ONE_NEXT_PROGRESS = new UserProgress(USER_ONE, NEXT_DATE,
+            new UserProgressTypeProgress(1, 2, NEXT_TIME), new UserProgressTypeProgress(1, 2, NEXT_TIME),
+            new UserProgressTypeProgress(1, 2, NEXT_TIME), new UserProgressTypeProgress(1, 2, NEXT_TIME));
 
     private static final User USER_TWO = new User(1002L, "UserTwo", NEXT_TIME);
-    private static final UserProgress USER_TWO_INC_PROGRESS = new UserProgress(USER_TWO,
-            UserProgressType.DAILY_INCREASE, DATE, 10, 10, TIME);
-    private static final UserProgress USER_TWO_NEXT_PROGRESS = new UserProgress(USER_TWO,
-            UserProgressType.DAILY_INCREASE, NEXT_DATE, 11, 12, TIME);
+    private static final UserProgress USER_TWO_PROGRESS = new UserProgress(USER_TWO, DATE,
+            new UserProgressTypeProgress(10, 10, TIME), new UserProgressTypeProgress(4, 4, TIME),
+            new UserProgressTypeProgress(6, 6, TIME), new UserProgressTypeProgress(4, 4, TIME));
+    private static final UserProgress USER_TWO_NEXT_PROGRESS = new UserProgress(USER_TWO, NEXT_DATE,
+            new UserProgressTypeProgress(10, 11, NEXT_TIME), new UserProgressTypeProgress(4, 4, NEXT_TIME),
+            new UserProgressTypeProgress(6, 7, NEXT_TIME), new UserProgressTypeProgress(4, 4, NEXT_TIME));
 
-    private static final List<UserProgress> SORTED_USER_PROGRESS = List.of(USER_ONE_INC_PROGRESS,
-            USER_ONE_NEXT_PROGRESS, USER_ONE_ADD_PROGRESS, USER_TWO_INC_PROGRESS, USER_TWO_NEXT_PROGRESS);
-
-    private static final List<UserProgress> USER_ONE_SORTED_USER_PROGRESS = List.of(USER_ONE_INC_PROGRESS,
-            USER_ONE_NEXT_PROGRESS, USER_ONE_ADD_PROGRESS);
-    private static final List<UserProgress> USER_TWO_SORTED_USER_PROGRESS = List.of(USER_TWO_INC_PROGRESS,
+    private static final List<UserProgress> SORTED_USER_PROGRESS = List.of(USER_ONE_PROGRESS, USER_ONE_NEXT_PROGRESS,
+            USER_TWO_PROGRESS, USER_TWO_NEXT_PROGRESS);
+    private static final List<UserProgress> USER_ONE_SORTED_USER_PROGRESS = List.of(USER_ONE_PROGRESS,
+            USER_ONE_NEXT_PROGRESS);
+    private static final List<UserProgress> USER_TWO_SORTED_USER_PROGRESS = List.of(USER_TWO_PROGRESS,
             USER_TWO_NEXT_PROGRESS);
 
     @Autowired
@@ -55,76 +56,68 @@ public class UserProgressRepositoryIntegrationTest {
     public void withUserProgress_whenFindById_thenExistingReturned() {
         entityManager.persist(USER_ONE);
         entityManager.persist(USER_TWO);
-        entityManager.persist(USER_ONE_INC_PROGRESS);
-        entityManager.persist(USER_ONE_ADD_PROGRESS);
+        entityManager.persist(USER_ONE_PROGRESS);
         entityManager.persist(USER_ONE_NEXT_PROGRESS);
-        entityManager.persist(USER_TWO_INC_PROGRESS);
+        entityManager.persist(USER_TWO_PROGRESS);
         entityManager.persist(USER_TWO_NEXT_PROGRESS);
 
         UserProgress userProgress = userProgressRepository.findById(
-                new UserProgressId(USER_ONE_INC_PROGRESS.getUser().getId(), USER_ONE_INC_PROGRESS.getType(),
-                        USER_ONE_INC_PROGRESS.getDate())).orElse(null);
-        assertEquals(USER_ONE_INC_PROGRESS, userProgress);
-        assertEquals(USER_ONE_ADD_PROGRESS, userProgressRepository.findById(
-                new UserProgressId(USER_ONE.getId(), UserProgressType.DAILY_ADD, DATE)).orElse(null));
-        assertEquals(USER_ONE_NEXT_PROGRESS, userProgressRepository.findById(
-                new UserProgressId(USER_ONE.getId(), UserProgressType.DAILY_INCREASE, NEXT_DATE)).orElse(null));
-        assertEquals(USER_TWO_INC_PROGRESS, userProgressRepository.findById(
-                new UserProgressId(USER_TWO.getId(), UserProgressType.DAILY_INCREASE, DATE)).orElse(null));
-        assertEquals(USER_TWO_NEXT_PROGRESS, userProgressRepository.findById(
-                new UserProgressId(USER_TWO.getId(), UserProgressType.DAILY_INCREASE, NEXT_DATE)).orElse(null));
+                new UserProgressId(USER_ONE_PROGRESS.getUser().getId(), USER_ONE_PROGRESS.getDate())).orElse(null);
+        assertEquals(USER_ONE_PROGRESS, userProgress);
+        assertEquals(USER_ONE_NEXT_PROGRESS,
+                userProgressRepository.findById(new UserProgressId(USER_ONE.getId(), NEXT_DATE)).orElse(null));
+        assertEquals(USER_TWO_PROGRESS,
+                userProgressRepository.findById(new UserProgressId(USER_TWO.getId(), DATE)).orElse(null));
+        assertEquals(USER_TWO_NEXT_PROGRESS,
+                userProgressRepository.findById(new UserProgressId(USER_TWO.getId(), NEXT_DATE)).orElse(null));
 
-        assertNull(userProgressRepository.findById(new UserProgressId(1000L, USER_ONE_INC_PROGRESS.getType(),
-                        USER_ONE_INC_PROGRESS.getDate())).orElse(null));
+        assertNull(
+                userProgressRepository.findById(new UserProgressId(1000L, USER_ONE_PROGRESS.getDate())).orElse(null));
         assertNull(userProgressRepository.findById(
-                new UserProgressId(USER_ONE.getId(), UserProgressType.DAILY_FIBONACCI, DATE)).orElse(null));
-        assertNull(userProgressRepository.findById(new UserProgressId(USER_ONE.getId(), USER_ONE_INC_PROGRESS.getType(),
-                NEXT_DATE.plus(1, ChronoUnit.DAYS))).orElse(null));
+                new UserProgressId(USER_ONE.getId(), NEXT_DATE.plus(1, ChronoUnit.DAYS))).orElse(null));
     }
 
     @Test
     public void givenNewUserProgress_whenSave_thenSaved() {
         entityManager.persist(USER_ONE);
 
-        UserProgress savedUserProgress = userProgressRepository.save(USER_ONE_INC_PROGRESS);
-        assertEquals(USER_ONE_INC_PROGRESS, entityManager.find(UserProgress.class,
-                new UserProgressId(savedUserProgress.getUser().getId(), savedUserProgress.getType(),
-                        savedUserProgress.getDate())));
+        UserProgress savedUserProgress = userProgressRepository.save(USER_ONE_PROGRESS);
+        assertEquals(USER_ONE_PROGRESS, entityManager.find(UserProgress.class,
+                new UserProgressId(savedUserProgress.getUser().getId(), savedUserProgress.getDate())));
 
-        assertThrows(EntityExistsException.class, () -> entityManager.persist(USER_ONE_INC_PROGRESS));
+        assertThrows(EntityExistsException.class, () -> entityManager.persist(USER_ONE_PROGRESS));
     }
 
     @Test
     public void givenUserProgress_whenUpdate_thenUpdated() {
-        UserProgress userProgress = new UserProgress(USER_TWO, UserProgressType.DAILY_POWER_OF_TWO, DATE, 5, 4, TIME);
+        UserProgress userProgress = new UserProgress(USER_TWO, DATE, new UserProgressTypeProgress(10, 10, TIME),
+                new UserProgressTypeProgress(4, 4, TIME), new UserProgressTypeProgress(6, 6, TIME),
+                new UserProgressTypeProgress(4, 4, TIME));
         entityManager.persist(userProgress);
 
-        userProgress.setDayCompleted(userProgress.getDayCompleted() + 1);
-        userProgress.setTimeCompleted(TIME.plusSeconds(60));
+        userProgress.getIncrease().setCompleted(userProgress.getIncrease().getCompleted() + 1);
+        userProgress.getIncrease().setTime(TIME.plusSeconds(60));
         UserProgress savedUserProgress = userProgressRepository.save(userProgress);
         assertEquals(userProgress, entityManager.find(UserProgress.class,
-                new UserProgressId(savedUserProgress.getUser().getId(), savedUserProgress.getType(),
-                        savedUserProgress.getDate())));
+                new UserProgressId(savedUserProgress.getUser().getId(), savedUserProgress.getDate())));
     }
 
     @Test
     public void givenUserProgress_whenFindAllSorted_thenAllReturned() {
-        entityManager.persist(USER_ONE_ADD_PROGRESS);
         entityManager.persist(USER_TWO_NEXT_PROGRESS);
-        entityManager.persist(USER_TWO_INC_PROGRESS);
+        entityManager.persist(USER_TWO_PROGRESS);
         entityManager.persist(USER_ONE_NEXT_PROGRESS);
-        entityManager.persist(USER_ONE_INC_PROGRESS);
+        entityManager.persist(USER_ONE_PROGRESS);
 
         assertEquals(SORTED_USER_PROGRESS, userProgressRepository.findAllSorted(UserProgress.class));
     }
 
     @Test
     public void givenUserProgress_whenFindAllSortedByUser_thenListReturned() {
-        entityManager.persist(USER_ONE_ADD_PROGRESS);
         entityManager.persist(USER_TWO_NEXT_PROGRESS);
-        entityManager.persist(USER_TWO_INC_PROGRESS);
+        entityManager.persist(USER_TWO_PROGRESS);
         entityManager.persist(USER_ONE_NEXT_PROGRESS);
-        entityManager.persist(USER_ONE_INC_PROGRESS);
+        entityManager.persist(USER_ONE_PROGRESS);
 
         assertEquals(USER_ONE_SORTED_USER_PROGRESS,
                 userProgressRepository.findAllSortedByUser(USER_ONE.getId(), UserProgress.class));

--- a/src/test/java/org/joelson/turf/dailyinc/model/UserProgressTest.java
+++ b/src/test/java/org/joelson/turf/dailyinc/model/UserProgressTest.java
@@ -14,177 +14,139 @@ public class UserProgressTest {
 
     private static final Instant TIME = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     private static final User USER = new User(1L, "User", TIME);
-    private static final UserProgressType TYPE = UserProgressType.DAILY_INCREASE;
     private static final Instant DATE = TIME.truncatedTo(ChronoUnit.DAYS);
     private static final int PREVIOUS_DAY_COMPLETED = 5;
     private static final int DAY_COMPLETED = 1;
 
+    private static final UserProgressTypeProgress USER_TYPE_PROGRESS
+            = new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME);
+
     @Test
     public void testUser() {
         assertThrows(NullPointerException.class,
-                () -> new UserProgress(null, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME));
+                () -> new UserProgress(null, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS));
 
         User user = new User(USER.getId() * 2, USER.getName() + "Name", TIME.plusSeconds(3));
         assertNotEquals(USER, user);
-        UserProgress userProgress = new UserProgress(user, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME);
+        UserProgress userProgress = new UserProgress(user, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                USER_TYPE_PROGRESS, USER_TYPE_PROGRESS);
         assertEquals(user, userProgress.getUser());
-    }
-
-    @Test
-    public void testType() {
-        assertThrows(NullPointerException.class,
-                () -> new UserProgress(USER, null, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME));
-
-        UserProgressType type = UserProgressType.DAILY_ADD;
-        assertNotEquals(type, TYPE);
-        UserProgress userProgress = new UserProgress(USER, type, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME);
-        assertEquals(type, userProgress.getType());
     }
 
     @Test
     public void testDate() {
         assertThrows(NullPointerException.class,
-                () -> new UserProgress(USER, TYPE, null, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME));
+                () -> new UserProgress(USER, null, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS));
         assertThrows(IllegalArgumentException.class,
-                () -> new UserProgress(USER, TYPE, DATE.plusSeconds(3), PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME));
+                () -> new UserProgress(USER, DATE.plusSeconds(3), USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS, USER_TYPE_PROGRESS));
 
         Instant date = DATE.plus(3, ChronoUnit.DAYS);
         assertNotEquals(DATE, date);
-        UserProgress userProgress = new UserProgress(USER, TYPE, date, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME);
+        UserProgress userProgress = new UserProgress(USER, date, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                USER_TYPE_PROGRESS, USER_TYPE_PROGRESS);
         assertEquals(date, userProgress.getDate());
     }
 
     @Test
-    public void testPreviousDayCompleted() {
-        assertThrows(NullPointerException.class, () -> new UserProgress(USER, TYPE, DATE, null, DAY_COMPLETED, TIME));
-        assertThrows(IllegalArgumentException.class, () -> new UserProgress(USER, TYPE, DATE, -1, DAY_COMPLETED, TIME));
-        assertDoesNotThrow(() -> new UserProgress(USER, TYPE, DATE, 0, DAY_COMPLETED, TIME));
-
-        Integer previousDayCompleted = PREVIOUS_DAY_COMPLETED + 3;
-        assertNotEquals(PREVIOUS_DAY_COMPLETED, previousDayCompleted);
-        UserProgress userProgress = new UserProgress(USER, TYPE, DATE, previousDayCompleted, DAY_COMPLETED, TIME);
-        assertEquals(previousDayCompleted, userProgress.getPreviousDayCompleted());
-    }
-
-    @Test
-    public void testDayCompleted() {
+    public void testIncrease() {
         assertThrows(NullPointerException.class,
-                () -> new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, null, TIME));
-        assertThrows(IllegalArgumentException.class,
-                () -> new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, 0, TIME));
-        assertThrows(IllegalArgumentException.class,
-                () -> new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, -1, TIME));
-        assertThrows(IllegalArgumentException.class,
-                () -> new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, 7, TIME));
+                () -> new UserProgress(USER, DATE, null, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS));
+        assertDoesNotThrow(
+                () -> new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS));
 
-        Integer dayCompleted = DAY_COMPLETED + 4;
-        assertNotEquals(DAY_COMPLETED, dayCompleted);
-        UserProgress userProgress = new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, dayCompleted, TIME);
-        assertEquals(dayCompleted, userProgress.getDayCompleted());
-
-        Integer newDayCompleted = dayCompleted + 1;
-        assertNotEquals(DAY_COMPLETED, newDayCompleted);
-        assertNotEquals(dayCompleted, newDayCompleted);
-        userProgress.setDayCompleted(newDayCompleted);
-        assertEquals(newDayCompleted, userProgress.getDayCompleted());
-
-        assertThrows(NullPointerException.class, () -> userProgress.setDayCompleted(null));
-        assertThrows(IllegalArgumentException.class, () -> userProgress.setDayCompleted(0));
-        assertThrows(IllegalArgumentException.class, () -> userProgress.setDayCompleted(dayCompleted));
-    }
-
-    @Test
-    public void testTimeCompleted() {
-        assertThrows(NullPointerException.class,
-                () -> new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, null));
-        assertThrows(IllegalArgumentException.class,
-                () -> new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME.plusNanos(3)));
-
-        Instant timeCompleted = TIME.plusSeconds(5);
-        assertNotEquals(TIME, timeCompleted);
-        UserProgress userProgress = new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED,
-                timeCompleted);
-        assertEquals(timeCompleted, userProgress.getTimeCompleted());
-
-        Instant newTimeCompleted = timeCompleted.plusSeconds(5);
-        assertNotEquals(TIME, newTimeCompleted);
-        assertNotEquals(timeCompleted, newTimeCompleted);
-        userProgress.setTimeCompleted(newTimeCompleted);
-        assertEquals(newTimeCompleted, userProgress.getTimeCompleted());
-
-        assertThrows(NullPointerException.class, () -> userProgress.setTimeCompleted(null));
-        assertThrows(IllegalArgumentException.class,
-                () -> userProgress.setTimeCompleted(newTimeCompleted.plusNanos(4)));
-        assertThrows(IllegalArgumentException.class, () -> userProgress.setTimeCompleted(timeCompleted));
+        UserProgressTypeProgress userProgressTypeProgress = new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED + 3,
+                DAY_COMPLETED, TIME);
+        assertNotEquals(USER_TYPE_PROGRESS, userProgressTypeProgress);
+        UserProgress userProgress = new UserProgress(USER, DATE, userProgressTypeProgress, USER_TYPE_PROGRESS,
+                USER_TYPE_PROGRESS, USER_TYPE_PROGRESS);
+        assertEquals(userProgressTypeProgress, userProgress.getIncrease());
+        userProgress = new UserProgress(USER, DATE, USER_TYPE_PROGRESS, userProgressTypeProgress, USER_TYPE_PROGRESS,
+                USER_TYPE_PROGRESS);
+        assertEquals(userProgressTypeProgress, userProgress.getAdd());
+        userProgress = new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, userProgressTypeProgress,
+                USER_TYPE_PROGRESS);
+        assertEquals(userProgressTypeProgress, userProgress.getFibonnaci());
+        userProgress = new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                userProgressTypeProgress);
+        assertEquals(userProgressTypeProgress, userProgress.getPowerOfTwo());
     }
 
     @Test
     public void testEquals() {
-        UserProgress userProgress = new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME);
+        UserProgress userProgress = new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                USER_TYPE_PROGRESS, USER_TYPE_PROGRESS);
         assertEquals(userProgress, userProgress);
         assertNotEquals(userProgress, null);
         assertNotEquals(userProgress, new UserProgress());
 
         User user = new User(USER.getId() * 2, USER.getName() + "Name", TIME.plusSeconds(3));
         assertNotEquals(USER, user);
-        assertNotEquals(userProgress, new UserProgress(user, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME));
-
-        UserProgressType type = UserProgressType.DAILY_ADD;
-        assertNotEquals(type, TYPE);
-        assertNotEquals(userProgress, new UserProgress(USER, type, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME));
+        assertNotEquals(userProgress,
+                new UserProgress(user, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS));
 
         Instant date = DATE.plus(3, ChronoUnit.DAYS);
         assertNotEquals(DATE, date);
-        assertNotEquals(userProgress, new UserProgress(USER, TYPE, date, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME));
+        assertNotEquals(userProgress,
+                new UserProgress(USER, date, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS));
 
         Integer previousDayCompleted = PREVIOUS_DAY_COMPLETED + 3;
-        assertNotEquals(PREVIOUS_DAY_COMPLETED, previousDayCompleted);
-        assertNotEquals(userProgress, new UserProgress(USER, TYPE, DATE, previousDayCompleted, DAY_COMPLETED, TIME));
-
-        Integer dayCompleted = DAY_COMPLETED + 3;
-        assertNotEquals(DAY_COMPLETED, dayCompleted);
-        assertNotEquals(userProgress, new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, dayCompleted, TIME));
-
-        Instant timeCompleted = TIME.plusSeconds(5);
-        assertNotEquals(TIME, timeCompleted);
+        UserProgressTypeProgress userProgressTypeProgress = new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED + 3,
+                DAY_COMPLETED, TIME);
+        assertNotEquals(USER_TYPE_PROGRESS, previousDayCompleted);
         assertNotEquals(userProgress,
-                new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, timeCompleted));
+                new UserProgress(USER, DATE, userProgressTypeProgress, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS));
+        assertNotEquals(userProgress,
+                new UserProgress(USER, DATE, USER_TYPE_PROGRESS, userProgressTypeProgress, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS));
+        assertNotEquals(userProgress,
+                new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, userProgressTypeProgress,
+                        USER_TYPE_PROGRESS));
+        assertNotEquals(userProgress,
+                new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        userProgressTypeProgress));
     }
 
     @Test
     public void testHashCode() {
-        UserProgress userProgress = new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME);
+        UserProgress userProgress = new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                USER_TYPE_PROGRESS, USER_TYPE_PROGRESS);
         assertEquals(userProgress.hashCode(), userProgress.hashCode());
         assertNotEquals(userProgress.hashCode(), new UserProgress().hashCode());
 
         User user = new User(USER.getId() * 2, USER.getName() + "Name", TIME.plusSeconds(3));
         assertNotEquals(USER, user);
         assertNotEquals(userProgress.hashCode(),
-                new UserProgress(user, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME).hashCode());
-
-        UserProgressType type = UserProgressType.DAILY_ADD;
-        assertNotEquals(type, TYPE);
-        assertNotEquals(userProgress.hashCode(),
-                new UserProgress(USER, type, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME).hashCode());
+                new UserProgress(user, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS).hashCode());
 
         Instant date = DATE.plus(3, ChronoUnit.DAYS);
         assertNotEquals(DATE, date);
         assertNotEquals(userProgress.hashCode(),
-                new UserProgress(USER, TYPE, date, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME).hashCode());
+                new UserProgress(USER, date, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS).hashCode());
 
         Integer previousDayCompleted = PREVIOUS_DAY_COMPLETED + 3;
-        assertNotEquals(PREVIOUS_DAY_COMPLETED, previousDayCompleted);
+        UserProgressTypeProgress userProgressTypeProgress = new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED + 3,
+                DAY_COMPLETED, TIME);
+        assertNotEquals(USER_TYPE_PROGRESS, previousDayCompleted);
         assertEquals(userProgress.hashCode(),
-                new UserProgress(USER, TYPE, DATE, previousDayCompleted, DAY_COMPLETED, TIME).hashCode());
-
-        Integer dayCompleted = DAY_COMPLETED + 3;
-        assertNotEquals(DAY_COMPLETED, dayCompleted);
+                new UserProgress(USER, DATE, userProgressTypeProgress, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS).hashCode());
         assertEquals(userProgress.hashCode(),
-                new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, dayCompleted, TIME).hashCode());
-
-        Instant timeCompleted = TIME.plusSeconds(5);
-        assertNotEquals(TIME, timeCompleted);
+                new UserProgress(USER, DATE, USER_TYPE_PROGRESS, userProgressTypeProgress, USER_TYPE_PROGRESS,
+                        USER_TYPE_PROGRESS).hashCode());
         assertEquals(userProgress.hashCode(),
-                new UserProgress(USER, TYPE, DATE, PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, timeCompleted).hashCode());
+                new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, userProgressTypeProgress,
+                        USER_TYPE_PROGRESS).hashCode());
+        assertEquals(userProgress.hashCode(),
+                new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
+                        userProgressTypeProgress).hashCode());
     }
 }

--- a/src/test/java/org/joelson/turf/dailyinc/model/UserProgressTest.java
+++ b/src/test/java/org/joelson/turf/dailyinc/model/UserProgressTest.java
@@ -69,7 +69,7 @@ public class UserProgressTest {
         assertEquals(userProgressTypeProgress, userProgress.getAdd());
         userProgress = new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, userProgressTypeProgress,
                 USER_TYPE_PROGRESS);
-        assertEquals(userProgressTypeProgress, userProgress.getFibonnaci());
+        assertEquals(userProgressTypeProgress, userProgress.getFibonacci());
         userProgress = new UserProgress(USER, DATE, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS, USER_TYPE_PROGRESS,
                 userProgressTypeProgress);
         assertEquals(userProgressTypeProgress, userProgress.getPowerOfTwo());

--- a/src/test/java/org/joelson/turf/dailyinc/model/UserProgressTypeProgressTest.java
+++ b/src/test/java/org/joelson/turf/dailyinc/model/UserProgressTypeProgressTest.java
@@ -1,0 +1,130 @@
+package org.joelson.turf.dailyinc.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UserProgressTypeProgressTest {
+
+    private static final Instant TIME = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    private static final int PREVIOUS_DAY_COMPLETED = 5;
+    private static final int DAY_COMPLETED = 1;
+
+    @Test
+    public void testPrevious() {
+        assertThrows(NullPointerException.class, () -> new UserProgressTypeProgress(null, DAY_COMPLETED, TIME));
+        assertThrows(IllegalArgumentException.class, () -> new UserProgressTypeProgress(-1, DAY_COMPLETED, TIME));
+        assertDoesNotThrow(() -> new UserProgressTypeProgress(0, DAY_COMPLETED, TIME));
+
+        Integer previous = PREVIOUS_DAY_COMPLETED + 3;
+        assertNotEquals(PREVIOUS_DAY_COMPLETED, previous);
+        UserProgressTypeProgress userProgressTypeProgress = new UserProgressTypeProgress(previous, DAY_COMPLETED, TIME);
+        assertEquals(previous, userProgressTypeProgress.getPrevious());
+    }
+
+    @Test
+    public void testCompleted() {
+        assertThrows(NullPointerException.class,
+                () -> new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, null, TIME));
+        assertThrows(IllegalArgumentException.class,
+                () -> new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, 0, TIME));
+        assertThrows(IllegalArgumentException.class,
+                () -> new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, -1, TIME));
+        assertThrows(IllegalArgumentException.class,
+                () -> new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, 7, TIME));
+
+        Integer completed = DAY_COMPLETED + 4;
+        assertNotEquals(DAY_COMPLETED, completed);
+        UserProgressTypeProgress userProgressTypeProgress = new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED,
+                completed, TIME);
+        assertEquals(completed, userProgressTypeProgress.getCompleted());
+
+        Integer newDayCompleted = completed + 1;
+        assertNotEquals(DAY_COMPLETED, newDayCompleted);
+        assertNotEquals(completed, newDayCompleted);
+        userProgressTypeProgress.setCompleted(newDayCompleted);
+        assertEquals(newDayCompleted, userProgressTypeProgress.getCompleted());
+
+        assertThrows(NullPointerException.class, () -> userProgressTypeProgress.setCompleted(null));
+        assertThrows(IllegalArgumentException.class, () -> userProgressTypeProgress.setCompleted(0));
+        assertThrows(IllegalArgumentException.class, () -> userProgressTypeProgress.setCompleted(completed));
+    }
+
+    @Test
+    public void testTime() {
+        assertThrows(NullPointerException.class,
+                () -> new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, TIME.plusNanos(3)));
+
+        Instant timeCompleted = TIME.plusSeconds(5);
+        assertNotEquals(TIME, timeCompleted);
+        UserProgressTypeProgress userProgressTypeProgress = new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED,
+                DAY_COMPLETED, timeCompleted);
+        assertEquals(timeCompleted, userProgressTypeProgress.getTime());
+
+        Instant newTimeCompleted = timeCompleted.plusSeconds(5);
+        assertNotEquals(TIME, newTimeCompleted);
+        assertNotEquals(timeCompleted, newTimeCompleted);
+        userProgressTypeProgress.setTime(newTimeCompleted);
+        assertEquals(newTimeCompleted, userProgressTypeProgress.getTime());
+
+        assertThrows(NullPointerException.class, () -> userProgressTypeProgress.setTime(null));
+        assertThrows(IllegalArgumentException.class,
+                () -> userProgressTypeProgress.setTime(newTimeCompleted.plusNanos(4)));
+        assertThrows(IllegalArgumentException.class, () -> userProgressTypeProgress.setTime(timeCompleted));
+    }
+
+    @Test
+    public void testEquals() {
+        UserProgressTypeProgress userProgressTypeProgress = new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED,
+                DAY_COMPLETED, TIME);
+        assertEquals(userProgressTypeProgress, userProgressTypeProgress);
+        assertNotEquals(userProgressTypeProgress, null);
+        assertNotEquals(userProgressTypeProgress, new UserProgressTypeProgress());
+
+        Integer previousDayCompleted = PREVIOUS_DAY_COMPLETED + 3;
+        assertNotEquals(PREVIOUS_DAY_COMPLETED, previousDayCompleted);
+        assertNotEquals(userProgressTypeProgress,
+                new UserProgressTypeProgress(previousDayCompleted, DAY_COMPLETED, TIME));
+
+        Integer dayCompleted = DAY_COMPLETED + 3;
+        assertNotEquals(DAY_COMPLETED, dayCompleted);
+        assertNotEquals(userProgressTypeProgress,
+                new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, dayCompleted, TIME));
+
+        Instant timeCompleted = TIME.plusSeconds(5);
+        assertNotEquals(TIME, timeCompleted);
+        assertNotEquals(userProgressTypeProgress,
+                new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, timeCompleted));
+    }
+
+    @Test
+    public void testHashCode() {
+        UserProgressTypeProgress userProgressTypeProgress = new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED,
+                DAY_COMPLETED, TIME);
+        assertEquals(userProgressTypeProgress.hashCode(), userProgressTypeProgress.hashCode());
+        assertNotEquals(userProgressTypeProgress.hashCode(), new UserProgressTypeProgress().hashCode());
+
+        Integer previousDayCompleted = PREVIOUS_DAY_COMPLETED + 3;
+        assertNotEquals(PREVIOUS_DAY_COMPLETED, previousDayCompleted);
+        assertNotEquals(userProgressTypeProgress.hashCode(),
+                new UserProgressTypeProgress(previousDayCompleted, DAY_COMPLETED, TIME).hashCode());
+
+        Integer dayCompleted = DAY_COMPLETED + 3;
+        assertNotEquals(DAY_COMPLETED, dayCompleted);
+        assertNotEquals(userProgressTypeProgress.hashCode(),
+                new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, dayCompleted, TIME).hashCode());
+
+        Instant timeCompleted = TIME.plusSeconds(5);
+        assertNotEquals(TIME, timeCompleted);
+        assertNotEquals(userProgressTypeProgress.hashCode(),
+                new UserProgressTypeProgress(PREVIOUS_DAY_COMPLETED, DAY_COMPLETED, timeCompleted).hashCode());
+    }
+}

--- a/src/test/java/org/joelson/turf/dailyinc/service/UserProgressServiceTest.java
+++ b/src/test/java/org/joelson/turf/dailyinc/service/UserProgressServiceTest.java
@@ -5,6 +5,7 @@ import org.joelson.turf.dailyinc.model.UserProgress;
 import org.joelson.turf.dailyinc.model.UserProgressId;
 import org.joelson.turf.dailyinc.model.UserProgressRepository;
 import org.joelson.turf.dailyinc.model.UserProgressType;
+import org.joelson.turf.dailyinc.model.UserProgressTypeProgress;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -46,37 +47,37 @@ public class UserProgressServiceTest {
 
     private static final User USER = new User(1001L, "User", NEXT_TIME);
 
-    private static final UserProgressId USER_INC_PROGRESS_ID = new UserProgressId(USER.getId(), UserProgressType.DAILY_INCREASE, DATE);
-    private static final UserProgressId USER_ADD_PROGRESS_ID = new UserProgressId(USER.getId(), UserProgressType.DAILY_ADD, DATE);
-    private static final UserProgressId USER_FIB_PROGRESS_ID = new UserProgressId(USER.getId(), UserProgressType.DAILY_FIBONACCI, DATE);
-    private static final UserProgressId USER_POW_PROGRESS_ID = new UserProgressId(USER.getId(), UserProgressType.DAILY_POWER_OF_TWO, DATE);
+    private static final UserProgressId USER_PROGRESS_ID = new UserProgressId(USER.getId(), DATE);
 
-    private static final UserProgress USER_INC_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_INCREASE, DATE, 0, 1, TIME);
-    private static final UserProgress USER_ADD_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_ADD, DATE, 0, 1, TIME);
-    private static final UserProgress USER_FIB_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_FIBONACCI, DATE, 0, 1, TIME);
-    private static final UserProgress USER_POW_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_POWER_OF_TWO, DATE, 0, 1, TIME);
+    private static final UserProgress USER_PROGRESS = new UserProgress(USER, DATE,
+            new UserProgressTypeProgress(0, 1, TIME), new UserProgressTypeProgress(0, 1, TIME),
+            new UserProgressTypeProgress(0, 1, TIME), new UserProgressTypeProgress(0, 1, TIME));
 
-    private static final UserProgressId NEXT_USER_INC_PROGRESS_ID = new UserProgressId(USER.getId(), UserProgressType.DAILY_INCREASE, NEXT_DATE);
-    private static final UserProgressId NEXT_USER_ADD_PROGRESS_ID = new UserProgressId(USER.getId(), UserProgressType.DAILY_ADD, NEXT_DATE);
-    private static final UserProgressId NEXT_USER_FIB_PROGRESS_ID = new UserProgressId(USER.getId(), UserProgressType.DAILY_FIBONACCI, NEXT_DATE);
-    private static final UserProgressId NEXT_USER_POW_PROGRESS_ID = new UserProgressId(USER.getId(), UserProgressType.DAILY_POWER_OF_TWO, NEXT_DATE);
+    private static final UserProgressId NEXT_USER_PROGRESS_ID = new UserProgressId(USER.getId(), NEXT_DATE);
 
-    private static final UserProgress NEXT_USER_INC_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_INCREASE, NEXT_DATE, 1, 1, NEXT_TIME);
-    private static final UserProgress NEXT_USER_ADD_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_ADD, NEXT_DATE, 1, 1, NEXT_TIME);
-    private static final UserProgress NEXT_USER_FIB_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_FIBONACCI, NEXT_DATE, 1, 2, NEXT_TIME);
-    private static final UserProgress NEXT_USER_POW_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_POWER_OF_TWO, NEXT_DATE, 1, 1, NEXT_TIME);
+    private static final UserProgress NEXT_USER_PROGRESS = new UserProgress(USER, NEXT_DATE,
+            new UserProgressTypeProgress(1, 1, NEXT_TIME), new UserProgressTypeProgress(1, 1, NEXT_TIME),
+            new UserProgressTypeProgress(1, 2, NEXT_TIME), new UserProgressTypeProgress(1, 1, NEXT_TIME));
 
     private static final Instant LATER_TIME = NEXT_TIME.plusSeconds(93);
 
-    private static final UserProgress LATER_USER_INC_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_INCREASE, NEXT_DATE, 1, 2, LATER_TIME);
-    private static final UserProgress LATER_USER_POW_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_POWER_OF_TWO, NEXT_DATE, 1, 2, LATER_TIME);
+    private static final UserProgress LATER_USER_PROGRESS = new UserProgress(USER, NEXT_DATE,
+            new UserProgressTypeProgress(1, 2, LATER_TIME), new UserProgressTypeProgress(1, 1, NEXT_TIME),
+            new UserProgressTypeProgress(1, 2, NEXT_TIME), new UserProgressTypeProgress(1, 2, LATER_TIME));
 
     private static final Instant EVEN_LATER_TIME = LATER_TIME.plusSeconds(129);
 
-    private static final UserProgress EVEN_LATER_USER_ADD_PROGRESS = new UserProgress(USER, UserProgressType.DAILY_ADD, NEXT_DATE, 1, 2, EVEN_LATER_TIME);
+    private static final UserProgress EVEN_LATER_USER_PROGRESS = new UserProgress(USER, NEXT_DATE,
+            new UserProgressTypeProgress(1, 2, LATER_TIME), new UserProgressTypeProgress(1, 2, EVEN_LATER_TIME),
+            new UserProgressTypeProgress(1, 2, NEXT_TIME), new UserProgressTypeProgress(1, 2, LATER_TIME));
 
-    private static UserProgress copyOf(UserProgress userProgress) {
-        return new UserProgress(userProgress.getUser(), userProgress.getType(), userProgress.getDate(), userProgress.getPreviousDayCompleted(), userProgress.getDayCompleted(), userProgress.getTimeCompleted());
+    private static UserProgress copyOf(UserProgress that) {
+        return new UserProgress(that.getUser(), that.getDate(), copyOf(that.getIncrease()), copyOf(that.getAdd()),
+                copyOf(that.getFibonnaci()), copyOf(that.getPowerOfTwo()));
+    }
+
+    private static UserProgressTypeProgress copyOf(UserProgressTypeProgress that) {
+        return new UserProgressTypeProgress(that.getPrevious(), that.getCompleted(), that.getTime());
     }
 
     @Test
@@ -84,56 +85,32 @@ public class UserProgressServiceTest {
         when(userProgressRepository.findById(any(UserProgressId.class))).thenReturn(Optional.empty());
 
         int maxDayCompleted = userProgressService.increaseUserProgress(USER, DATE, 1, TIME);
-        assertEquals(USER_INC_PROGRESS.getDayCompleted(), maxDayCompleted);
-        verify(userProgressRepository).findById(USER_INC_PROGRESS_ID);
-        verify(userProgressRepository).save(USER_INC_PROGRESS);
-        verify(userProgressRepository).findById(USER_ADD_PROGRESS_ID);
-        verify(userProgressRepository).save(USER_ADD_PROGRESS);
-        verify(userProgressRepository).findById(USER_FIB_PROGRESS_ID);
-        verify(userProgressRepository).save(USER_FIB_PROGRESS);
-        verify(userProgressRepository).findById(USER_POW_PROGRESS_ID);
-        verify(userProgressRepository).save(USER_POW_PROGRESS);
+        assertEquals(USER_PROGRESS.getIncrease().getCompleted(), maxDayCompleted);
+        verify(userProgressRepository).findById(USER_PROGRESS_ID);
+        verify(userProgressRepository).save(USER_PROGRESS);
     }
 
     @Test
     public void givenDateUserProgress_whenIncreaseUserProgress_thenProgressNotUpdated() {
         when(userProgressRepository.findById(any(UserProgressId.class))).thenReturn(Optional.empty());
-        when(userProgressRepository.findById(USER_INC_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_INC_PROGRESS)));
-        when(userProgressRepository.findById(USER_ADD_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_ADD_PROGRESS)));
-        when(userProgressRepository.findById(USER_FIB_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_FIB_PROGRESS)));
-        when(userProgressRepository.findById(USER_POW_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_POW_PROGRESS)));
+        when(userProgressRepository.findById(USER_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_PROGRESS)));
 
         int maxDayCompleted = userProgressService.increaseUserProgress(USER, DATE, 2, TIME.plusSeconds(60));
-        assertEquals(USER_INC_PROGRESS.getDayCompleted(), maxDayCompleted);
-        verify(userProgressRepository).findById(USER_INC_PROGRESS_ID);
-        verify(userProgressRepository).findById(USER_ADD_PROGRESS_ID);
-        verify(userProgressRepository).findById(USER_FIB_PROGRESS_ID);
-        verify(userProgressRepository).findById(USER_POW_PROGRESS_ID);
+        assertEquals(USER_PROGRESS.getIncrease().getCompleted(), maxDayCompleted);
+        verify(userProgressRepository).findById(USER_PROGRESS_ID);
         verify(userProgressRepository, never()).save(any(UserProgress.class));
     }
 
     @Test
     public void givenDateUserProgressButNoNextDateUserProgress_whenIncreaseUserProgress_thenProgressCreated() {
         when(userProgressRepository.findById(any(UserProgressId.class))).thenReturn(Optional.empty());
-        when(userProgressRepository.findById(USER_INC_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_INC_PROGRESS)));
-        when(userProgressRepository.findById(USER_ADD_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_ADD_PROGRESS)));
-        when(userProgressRepository.findById(USER_FIB_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_FIB_PROGRESS)));
-        when(userProgressRepository.findById(USER_POW_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_POW_PROGRESS)));
+        when(userProgressRepository.findById(USER_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_PROGRESS)));
 
         int maxDayCompleted = userProgressService.increaseUserProgress(USER, NEXT_DATE, 1, NEXT_TIME);
-        assertEquals(NEXT_USER_FIB_PROGRESS.getDayCompleted(), maxDayCompleted);
-        verify(userProgressRepository).findById(USER_INC_PROGRESS_ID);
-        verify(userProgressRepository).findById(NEXT_USER_INC_PROGRESS_ID);
-        verify(userProgressRepository).save(NEXT_USER_INC_PROGRESS);
-        verify(userProgressRepository).findById(USER_ADD_PROGRESS_ID);
-        verify(userProgressRepository).findById(NEXT_USER_ADD_PROGRESS_ID);
-        verify(userProgressRepository).save(NEXT_USER_ADD_PROGRESS);
-        verify(userProgressRepository).findById(USER_FIB_PROGRESS_ID);
-        verify(userProgressRepository).findById(NEXT_USER_FIB_PROGRESS_ID);
-        verify(userProgressRepository).save(NEXT_USER_FIB_PROGRESS);
-        verify(userProgressRepository).findById(USER_POW_PROGRESS_ID);
-        verify(userProgressRepository).findById(NEXT_USER_POW_PROGRESS_ID);
-        verify(userProgressRepository).save(NEXT_USER_POW_PROGRESS);
+        assertEquals(NEXT_USER_PROGRESS.getFibonnaci().getCompleted(), maxDayCompleted);
+        verify(userProgressRepository).findById(USER_PROGRESS_ID);
+        verify(userProgressRepository).findById(NEXT_USER_PROGRESS_ID);
+        verify(userProgressRepository).save(NEXT_USER_PROGRESS);
 
         /*ArgumentCaptor<UserProgress> saveArgumentCaptor = ArgumentCaptor.forClass(UserProgress.class);
         verify(userProgressRepository, times(4)).save(saveArgumentCaptor.capture());
@@ -151,35 +128,22 @@ public class UserProgressServiceTest {
     @Test
     public void givenNextDateUserProgress_whenIncreaseUserProgress_thenProgressUpdated() {
         when(userProgressRepository.findById(any(UserProgressId.class))).thenReturn(Optional.empty());
-        when(userProgressRepository.findById(NEXT_USER_INC_PROGRESS_ID)).thenReturn(Optional.of(copyOf(NEXT_USER_INC_PROGRESS)));
-        when(userProgressRepository.findById(NEXT_USER_ADD_PROGRESS_ID)).thenReturn(Optional.of(copyOf(NEXT_USER_ADD_PROGRESS)));
-        when(userProgressRepository.findById(NEXT_USER_FIB_PROGRESS_ID)).thenReturn(Optional.of(copyOf(NEXT_USER_FIB_PROGRESS)));
-        when(userProgressRepository.findById(NEXT_USER_POW_PROGRESS_ID)).thenReturn(Optional.of(copyOf(NEXT_USER_POW_PROGRESS)));
+        when(userProgressRepository.findById(NEXT_USER_PROGRESS_ID)).thenReturn(Optional.of(copyOf(NEXT_USER_PROGRESS)));
 
         int maxDayCompleted = userProgressService.increaseUserProgress(USER, NEXT_DATE, 2, LATER_TIME);
-        assertEquals(NEXT_USER_FIB_PROGRESS.getDayCompleted(), maxDayCompleted);
-        verify(userProgressRepository).findById(NEXT_USER_INC_PROGRESS_ID);
-        verify(userProgressRepository).save(LATER_USER_INC_PROGRESS);
-        verify(userProgressRepository).findById(NEXT_USER_ADD_PROGRESS_ID);
-        verify(userProgressRepository).findById(NEXT_USER_FIB_PROGRESS_ID);
-        verify(userProgressRepository).findById(NEXT_USER_POW_PROGRESS_ID);
-        verify(userProgressRepository).save(LATER_USER_POW_PROGRESS);
+        assertEquals(LATER_USER_PROGRESS.getIncrease().getCompleted(), maxDayCompleted);
+        verify(userProgressRepository).findById(NEXT_USER_PROGRESS_ID);
+        verify(userProgressRepository).save(LATER_USER_PROGRESS);
     }
 
     @Test
     public void givenNextDateLaterUserProgress_whenIncreaseUserProgress_thenProgressUpdated() {
         when(userProgressRepository.findById(any(UserProgressId.class))).thenReturn(Optional.empty());
-        when(userProgressRepository.findById(NEXT_USER_INC_PROGRESS_ID)).thenReturn(Optional.of(copyOf(LATER_USER_INC_PROGRESS)));
-        when(userProgressRepository.findById(NEXT_USER_ADD_PROGRESS_ID)).thenReturn(Optional.of(copyOf(NEXT_USER_ADD_PROGRESS)));
-        when(userProgressRepository.findById(NEXT_USER_FIB_PROGRESS_ID)).thenReturn(Optional.of(copyOf(NEXT_USER_FIB_PROGRESS)));
-        when(userProgressRepository.findById(NEXT_USER_POW_PROGRESS_ID)).thenReturn(Optional.of(copyOf(LATER_USER_POW_PROGRESS)));
+        when(userProgressRepository.findById(NEXT_USER_PROGRESS_ID)).thenReturn(Optional.of(copyOf(LATER_USER_PROGRESS)));
 
         int maxDayCompleted = userProgressService.increaseUserProgress(USER, NEXT_DATE, 3, EVEN_LATER_TIME);
-        assertEquals(NEXT_USER_FIB_PROGRESS.getDayCompleted(), maxDayCompleted);
-        verify(userProgressRepository).findById(NEXT_USER_INC_PROGRESS_ID);
-        verify(userProgressRepository).findById(NEXT_USER_ADD_PROGRESS_ID);
-        verify(userProgressRepository).save(EVEN_LATER_USER_ADD_PROGRESS);
-        verify(userProgressRepository).findById(NEXT_USER_FIB_PROGRESS_ID);
-        verify(userProgressRepository).findById(NEXT_USER_POW_PROGRESS_ID);
+        assertEquals(EVEN_LATER_USER_PROGRESS.getAdd().getCompleted(), maxDayCompleted);
+        verify(userProgressRepository).findById(NEXT_USER_PROGRESS_ID);
+        verify(userProgressRepository).save(EVEN_LATER_USER_PROGRESS);
     }
 }

--- a/src/test/java/org/joelson/turf/dailyinc/service/UserProgressServiceTest.java
+++ b/src/test/java/org/joelson/turf/dailyinc/service/UserProgressServiceTest.java
@@ -4,7 +4,6 @@ import org.joelson.turf.dailyinc.model.User;
 import org.joelson.turf.dailyinc.model.UserProgress;
 import org.joelson.turf.dailyinc.model.UserProgressId;
 import org.joelson.turf.dailyinc.model.UserProgressRepository;
-import org.joelson.turf.dailyinc.model.UserProgressType;
 import org.joelson.turf.dailyinc.model.UserProgressTypeProgress;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -73,7 +72,7 @@ public class UserProgressServiceTest {
 
     private static UserProgress copyOf(UserProgress that) {
         return new UserProgress(that.getUser(), that.getDate(), copyOf(that.getIncrease()), copyOf(that.getAdd()),
-                copyOf(that.getFibonnaci()), copyOf(that.getPowerOfTwo()));
+                copyOf(that.getFibonacci()), copyOf(that.getPowerOfTwo()));
     }
 
     private static UserProgressTypeProgress copyOf(UserProgressTypeProgress that) {
@@ -107,7 +106,7 @@ public class UserProgressServiceTest {
         when(userProgressRepository.findById(USER_PROGRESS_ID)).thenReturn(Optional.of(copyOf(USER_PROGRESS)));
 
         int maxDayCompleted = userProgressService.increaseUserProgress(USER, NEXT_DATE, 1, NEXT_TIME);
-        assertEquals(NEXT_USER_PROGRESS.getFibonnaci().getCompleted(), maxDayCompleted);
+        assertEquals(NEXT_USER_PROGRESS.getFibonacci().getCompleted(), maxDayCompleted);
         verify(userProgressRepository).findById(USER_PROGRESS_ID);
         verify(userProgressRepository).findById(NEXT_USER_PROGRESS_ID);
         verify(userProgressRepository).save(NEXT_USER_PROGRESS);


### PR DESCRIPTION
Instead of four rows based on type for each user and date, unify them into the user progress entity directly.